### PR TITLE
Implement custom cursor base logic

### DIFF
--- a/cursor.css
+++ b/cursor.css
@@ -16,10 +16,13 @@
 }
 /* cursor mode */
 .cursor-base {
-	
+  display: block;
 }
-.cursor-base--hover {
-	
+.cursor-base .hoverAnimPointArray {
+  display: none;
+}
+.cursor-base--hover .hoverAnimPointArray {
+  display: inline;
 }
 .cursor-base--active {
 	

--- a/cursor.js
+++ b/cursor.js
@@ -1,6 +1,35 @@
 const customCursor = document.getElementById('custom-cursor');
+// обновление позиции курсора
 document.addEventListener('mousemove', e => {
-  // Центрируем SVG под указателем (можно сместить по-другому)
   customCursor.style.left = (e.clientX - 26) + 'px';
   customCursor.style.top  = (e.clientY - 26) + 'px';
+});
+
+// элемент карты из scriptv2.js
+const mapContainer = document.getElementById('map');
+
+// показываем базовый курсор при наведении на карту
+mapContainer.addEventListener('mouseenter', () => {
+  customCursor.classList.add('cursor-base');
+  customCursor.classList.remove('cursor-base--hover');
+});
+
+// скрываем кастомный курсор при уходе с карты
+mapContainer.addEventListener('mouseleave', () => {
+  customCursor.classList.remove('cursor-base', 'cursor-base--hover');
+});
+
+// активные элементы, для которых нужно показывать анимацию hover
+const activeSelectors = '.leaflet-marker-icon, a, button, .leaflet-popup-close-button';
+
+document.addEventListener('mouseover', e => {
+  if (e.target.closest(activeSelectors)) {
+    customCursor.classList.add('cursor-base--hover');
+  }
+});
+
+document.addEventListener('mouseout', e => {
+  if (e.target.closest(activeSelectors)) {
+    customCursor.classList.remove('cursor-base--hover');
+  }
 });


### PR DESCRIPTION
## Summary
- hide hover points by default and show them on hover
- toggle cursor style for map vs active elements

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_683f924b973c832ebaa40f29cfe3a320